### PR TITLE
Fix return data for several functions

### DIFF
--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -231,7 +231,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
       
     const url = `${apiUrl}/${resource}?${query}`;
 
-    return httpClient(url).then(({ json }) => ({ data: json.map(data => encodeId(data, primaryKey)) }));
+    return httpClient(url).then(({ json }) => ({ data: json.map(data => ({...data, id: encodeId(data, primaryKey)})) }));
   },
 
   getManyReference: (resource, params) => {
@@ -267,7 +267,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
         );
       }
       return {
-        data: json.map(data => encodeId(data, primaryKey)),
+        data: json.map(data => ({...data, id: encodeId(data, primaryKey)})),
         total: parseInt(
           headers
             .get('content-range')
@@ -333,7 +333,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
       }),
       body,
     }).then(({ json }) => ({
-      data: json.map(data => encodeId(data, primaryKey))
+      data: json.map(data => ({...data, id: encodeId(data, primaryKey)}))
     }));
   },
 
@@ -390,6 +390,6 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
         'Prefer': 'return=representation',
         'Content-Type': 'application/json'
       }),
-    }).then(({ json }) => ({ data: json.map(data => encodeId(data, primaryKey)) }));
+    }).then(({ json }) => ({ data: json.map(data => ({...data, id: encodeId(data, primaryKey)})) }));
   },
 });


### PR DESCRIPTION
Some functions were calling encodeId and returning only the encoded IDs while throwing away the rest of the data, but I made them return all of the data along with the encoded IDs.