### PR TITLE
[BUGFIX] Ensure id is always pulled directly from the given params

### DIFF
--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -280,7 +280,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
   },
 
   update: (resource, params) => {
-    const { id, ...data } = params.data;
+    const { id, data } = params;
     const primaryKey = getPrimaryKey(resource, primaryKeys);
 
     const query = getQuery(primaryKey, id);


### PR DESCRIPTION
Currently all the data-provider methods use `params.id` or `params.ids` to determine the resource url except `update` which is using `params.data.id`.  This can cause issues as there is no guarantee that `params.data.id` will exist.

This PR makes `update` consistent with the other methods by using `params.id`.