### PR TITLE
Added eq. prefix for non-compound keys

### DIFF
--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -143,7 +143,7 @@ const getQuery = (primaryKey : PrimaryKey, ids: Identifier | Array<Identifier>, 
       else
         return `and=(${primaryKey.map((key : string, i: any) => `${key}.eq.${primaryKeyParams[i]}`).join(',')})`;
     } else {
-      return stringify({ [primaryKey[0]]: `${id}` });
+      return stringify({ [primaryKey[0]]: `eq.${id}` });
     }
   }
 }


### PR DESCRIPTION
This PR adds the `eq.` prefix back when a non-compound key is encountered by the getQuery function. 