### PR TITLE
Let the sort param in getList be optional

### DIFF
--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -178,16 +178,18 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, defaultListOp = 'eq',
     const primaryKey = getPrimaryKey(resource, primaryKeys);
 
     const { page, perPage } = params.pagination;
-    const { field, order } = params.sort;
+    const { field, order } = params.sort || {};
     const parsedFilter = parseFilters(params.filter, defaultListOp);
 
     const query = {
-      order: getOrderBy(field, order, primaryKey),
       offset: String((page - 1) * perPage),
       limit: String(perPage),
       // append filters
       ...parsedFilter
     };
+    if (field) {
+      query.order = getOrderBy(field, order, primaryKey);
+    }
 
     // add header that Content-Range is in returned header
     const options = {


### PR DESCRIPTION
It should be possible to use useGetList without a sort parameter. The postgrest client wil currently throw an error in such cases. This PR is to make the sort parameter optional, because the postgrest api will happily accept calls without the order query param.

```javascript
const { data } = useGetList('some-resource', { filter: {} });
```