### PR TITLE
use {} with cs and cd operators url

### DIFF
--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -77,16 +77,15 @@ export const parseFilters = (
         }
 
         values.forEach(value => {
-            // if operator is intentionally blank, rpc syntax
-            let op = `${operation}.${value}`;
-            if (operation.length == 0) {
-                op = `${value}`;
-            }
-            if (operation.includes('like')) {
-                op = `${operation}.*${value}*`;
-            } else if (['cs', 'cd'].includes(operation)) {
-                op = `${operation}.{${value}}`;
-            }
+            let op: string = (() => {
+                // if operator is intentionally blank, rpc syntax
+                if (operation.length === 0) return `${value}`;
+                if (operation.includes('like'))
+                    return `${operation}.*${value}*`;
+                if (['cs', 'cd'].includes(operation))
+                    return `${operation}.{${value}}`;
+                return `${operation}.${value}`;
+            })();
 
             if (result.filter[splitKey[0]] === undefined) {
                 // first operator for the key, we add it to the dict

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -78,13 +78,15 @@ export const parseFilters = (
 
         values.forEach(value => {
             // if operator is intentionally blank, rpc syntax
-            let op = operation.includes('like')
-                ? `${operation}.*${value}*`
-                : ['cs','cd'].includes(operation)
-                ? `${operation}.{${value}}`
-                : operation.length == 0
-                ? `${value}`
-                : `${operation}.${value}`;
+            let op = `${operation}.${value}`;
+            if (operation.length == 0) {
+                op = `${value}`;
+            }
+            if (operation.includes('like')) {
+                op = `${operation}.*${value}*`;
+            } else if (['cs', 'cd'].includes(operation)) {
+                op = `${operation}.{${value}}`;
+            }
 
             if (result.filter[splitKey[0]] === undefined) {
                 // first operator for the key, we add it to the dict

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -80,6 +80,8 @@ export const parseFilters = (
             // if operator is intentionally blank, rpc syntax
             let op = operation.includes('like')
                 ? `${operation}.*${value}*`
+                : ['cs','cd'].includes(operation)
+                ? `${operation}.{${value}}`
                 : operation.length == 0
                 ? `${value}`
                 : `${operation}.${value}`;

--- a/tests/urlBuilder/urlBuilder.test.ts
+++ b/tests/urlBuilder/urlBuilder.test.ts
@@ -28,6 +28,10 @@ describe('parseFilters', () => {
                         'q2@ilike': 'bar',
                         'q3@like': 'baz qux',
                         'q4@gt': 'c',
+                        'q5@cs': 'foo',
+                        'q6@cs': ['foo', 'bar'],
+                        'q7@cd': 'foo',
+                        'q8@cd': ['foo', 'bar'],
                     }
                 },
                 'eq'
@@ -38,6 +42,10 @@ describe('parseFilters', () => {
                 q2: 'ilike.*bar*',
                 q3: ['like.*baz*', 'like.*qux*'],
                 q4: 'gt.c',
+                q5: 'cs.{foo}',
+                q6: 'cs.{foo,bar}',
+                q7: 'cd.{foo}',
+                q8: 'cd.{foo,bar}',
             }
          });
     });


### PR DESCRIPTION
This PR propose a fix for issue #78 including both `cs` and `cd` operators.

It add the `{}` around the id in the query url.