### PR TITLE
[Doc] Fix Custom schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ PostgREST allows to [select and switch the database schema](https://postgrest.or
 ```jsx
 const config: IDataProviderConfig = {
     ...
-    schema: localStorage.getItem("schema") || "api",
+    schema: () => localStorage.getItem("schema") || "api",
     ...
 }
 


### PR DESCRIPTION
I believe the code example in the 'Custom schema' section of the docs is wrong, as the `schema` prop expects a function (`() => string`) and not a `string` directly.