### PR TITLE
[feature] Adding global sort order options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Access-Control-Expose-Headers: Content-Range
 // in src/App.js
 import * as React from 'react';
 import { Admin, Resource, fetchUtils } from 'react-admin';
-import postgrestRestProvider, 
-     { IDataProviderConfig, 
-       defaultPrimaryKeys, 
+import postgrestRestProvider,
+     { IDataProviderConfig,
+       defaultPrimaryKeys,
        defaultSchema } from '@raphiniert/ra-data-postgrest';
 
 import { PostList } from './posts';
@@ -194,13 +194,28 @@ const [create, { isLoading, error }] = useCreate(
 );
 ```
 
+### Null sort order
+Postgrest supports specifying the position of nulls in [sort ordering](https://postgrest.org/en/v12/references/api/tables_views.html#ordering). This can be configured via an optional data provider parameter:
+
+```jsx
+const config: IDataProviderConfig = {
+    ...
+    sortOrder: PostgRestSortOrder.AscendingNullsLastDescendingNullsLast
+    ...
+}
+
+const dataProvider = postgrestRestProvider(config);
+```
+
+It is important to note that null positioning in sort will impact index utilization so in some cases you'll want to add  corresponding index on the database side.
+
 ### Vertical filtering
 Postgrest supports a feature of [Vertical Filtering (Columns)](https://postgrest.org/en/stable/api.html#vertical-filtering-columns). Within the react-admin hooks this feature can be used as in the following example:
 
 ```jsx
 const { data, total, isLoading, error } = useGetList(
     'posts',
-    { 
+    {
         pagination: { page: 1, perPage: 10 },
         sort: { field: 'published_at', order: 'DESC' }
         meta: { columns: ['id', 'title'] }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
     removePrimaryKey,
     getQuery,
     encodeId,
+    PostgRestSortOrder,
 } from './urlBuilder';
 import qs from 'qs';
 import isEqual from 'lodash/isEqual';
@@ -82,6 +83,7 @@ export interface IDataProviderConfig {
     apiUrl: string;
     httpClient: (string, Options) => Promise<any>;
     defaultListOp: PostgRestOperator;
+    sortOrder?: PostgRestSortOrder;
     primaryKeys: Map<string, PrimaryKey>;
     schema: () => string;
 }
@@ -219,7 +221,7 @@ export default (config: IDataProviderConfig): DataProvider => ({
         let query = params.target
             ? {
                   [params.target]: `eq.${params.id}`,
-                  order: getOrderBy(field, order, primaryKey),
+                  order: getOrderBy(field, order, primaryKey, config.sortOrder),
                   offset: String((page - 1) * perPage),
                   limit: String(perPage),
                   ...filter,

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -298,14 +298,23 @@ export const getQuery = (
     return result;
 };
 
+export enum PostgRestSortOrder {
+    AscendingNullsLastDescendingNullsFirst = 'asc,desc',
+    AscendingNullsLastDescendingNullsLast = 'asc,desc.nullslast',
+    AscendingNullsFirstDescendingNullsFirst = 'asc.nullsfirst,desc',
+    AscendingNullsFirstDescendingNullsLast = 'asc.nullsfirst,desc.nullslast',
+}
+
 export const getOrderBy = (
     field: string,
     order: string,
-    primaryKey: PrimaryKey
+    primaryKey: PrimaryKey,
+    sortOrder: PostgRestSortOrder = PostgRestSortOrder.AscendingNullsLastDescendingNullsFirst
 ) => {
+    const postgRestOrder = sortOrder.split(',')[order === 'ASC' ? 0 : 1];
     if (field == 'id') {
-        return primaryKey.map(key => `${key}.${order.toLowerCase()}`).join(',');
+        return primaryKey.map(key => `${key}.${postgRestOrder}`).join(',');
     } else {
-        return `${field}.${order.toLowerCase()}`;
+        return `${field}.${postgRestOrder}`;
     }
 };


### PR DESCRIPTION
Adding sort orders options. They are a bit verbose but do explain themselves rather well. I can update docs but given it's an optional param I didn't want to confuse new users in the initial example. Also added a test that covers all cases. In the event a user selects an order that matches postgres natural sorting we don't append the null ordering param to keep behavior consistant with existing functionality.

Fixes #124 