### PR TITLE
Add support for React Admin v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "typescript": "^5.3.3"
             },
             "peerDependencies": {
-                "ra-core": "^4.1.0"
+                "ra-core": "^4.1.0 || ^5.0.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "typescript": "^5.3.3"
     },
     "peerDependencies": {
-        "ra-core": "^4.1.0"
+        "ra-core": "^4.1.0 || ^5.0.1"
     },
     "dependencies": {
         "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
According to my tests, the latest version of `ra-data-postgrest` seems to be fully compatible with `react-admin` v5.

Hence, this PR only updates the `peerDependencies` declaration to avoid package manager warning messages.