### PR TITLE
Add nullslast and nullsfirst support to getList

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,12 @@ const [create, { isLoading, error }] = useCreate(
 ```
 
 ### Null sort order
+
 Postgrest supports specifying the position of nulls in [sort ordering](https://postgrest.org/en/v12/references/api/tables_views.html#ordering). This can be configured via an optional data provider parameter:
 
 ```jsx
+import { PostgRestSortOrder, IDataProviderConfig } from '@raphiniert/ra-data-postgrest';
+
 const config: IDataProviderConfig = {
     ...
     sortOrder: PostgRestSortOrder.AscendingNullsLastDescendingNullsLast
@@ -207,7 +210,22 @@ const config: IDataProviderConfig = {
 const dataProvider = postgrestRestProvider(config);
 ```
 
+This parameter impacts the `getList` and `getManyReference` calls.
+
 It is important to note that null positioning in sort will impact index utilization so in some cases you'll want to add  corresponding index on the database side.
+
+You can also override this parameter on a per-query basis by passing `nullsfirst: true` or `nullslast: true` in the `meta` object of the query:
+
+```jsx
+const { data, total, isLoading, error } = useGetList(
+    'posts',
+    {
+        pagination: { page: 1, perPage: 10 },
+        sort: { field: 'published_at', order: 'DESC' },
+        meta: { nullslast: true }
+    }
+);
+```
 
 ### Vertical filtering
 Postgrest supports a feature of [Vertical Filtering (Columns)](https://postgrest.org/en/stable/api.html#vertical-filtering-columns). Within the react-admin hooks this feature can be used as in the following example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,8 @@ export const defaultPrimaryKeys = new Map<string, PrimaryKey>();
 
 export const defaultSchema = () => '';
 
+export { PostgRestSortOrder };
+
 export interface IDataProviderConfig {
     apiUrl: string;
     httpClient: (string, Options) => Promise<any>;
@@ -127,7 +129,37 @@ export default (config: IDataProviderConfig): DataProvider => ({
         };
 
         if (field) {
-            query.order = getOrderBy(field, order, primaryKey);
+            query.order = getOrderBy(
+                field,
+                order,
+                primaryKey,
+                config.sortOrder
+            );
+            if (
+                params.meta?.nullsfirst &&
+                !query.order.includes('nullsfirst')
+            ) {
+                query.order = query.order.includes('nullslast')
+                    ? query.order.replace('nullslast', 'nullsfirst')
+                    : `${query.order}.nullsfirst`;
+            }
+            if (
+                params.meta?.nullsfirst === false &&
+                query.order.includes('nullsfirst')
+            ) {
+                query.order = query.order.replace('.nullsfirst', '');
+            }
+            if (params.meta?.nullslast && !query.order.includes('nullslast')) {
+                query.order = query.order.includes('nullsfirst')
+                    ? query.order.replace('nullsfirst', 'nullslast')
+                    : `${query.order}.nullslast`;
+            }
+            if (
+                params.meta?.nullslast === false &&
+                query.order.includes('nullslast')
+            ) {
+                query.order = query.order.replace('.nullslast', '');
+            }
         }
 
         if (select) {

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -298,7 +298,7 @@ export const getQuery = (
     return result;
 };
 
-export enum PostgRestSortOrder {
+export const enum PostgRestSortOrder {
     AscendingNullsLastDescendingNullsFirst = 'asc,desc',
     AscendingNullsLastDescendingNullsLast = 'asc,desc.nullslast',
     AscendingNullsFirstDescendingNullsFirst = 'asc.nullsfirst,desc',

--- a/tests/dataProvider/getList.test.ts
+++ b/tests/dataProvider/getList.test.ts
@@ -1,4 +1,5 @@
 import { makeTestFromCase, Case } from './helper';
+import { PostgRestSortOrder } from '../../src/index';
 
 describe('getList specific', () => {
     const method = 'getList';
@@ -50,4 +51,252 @@ describe('getList specific', () => {
     ];
 
     cases.forEach(makeTestFromCase);
+
+    describe('meta', () => {
+        describe('nullsfirst', () => {
+            makeTestFromCase({
+                test: 'nullsfirst true added in meta changes the sort order',
+                method,
+                resource: 'posts',
+                params: {
+                    pagination: {
+                        page: 1,
+                        perPage: 10,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                    filter: {},
+                    meta: { nullsfirst: true },
+                },
+                expectedUrl: `/posts?offset=0&limit=10&order=id.asc.nullsfirst`,
+                expectedOptions: {
+                    headers: {
+                        accept: 'application/json',
+                        prefer: 'count=exact',
+                    },
+                },
+                httpClientResponseHeaders: {
+                    'content-range': '0-9/100',
+                },
+            });
+            makeTestFromCase({
+                test: 'nullsfirst true added in meta is compatible with the default sort order',
+                method,
+                config: {
+                    sortOrder:
+                        PostgRestSortOrder.AscendingNullsFirstDescendingNullsFirst,
+                },
+                resource: 'posts',
+                params: {
+                    pagination: {
+                        page: 1,
+                        perPage: 10,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                    filter: {},
+                    meta: { nullsfirst: true },
+                },
+                expectedUrl: `/posts?offset=0&limit=10&order=id.asc.nullsfirst`,
+                expectedOptions: {
+                    headers: {
+                        accept: 'application/json',
+                        prefer: 'count=exact',
+                    },
+                },
+                httpClientResponseHeaders: {
+                    'content-range': '0-9/100',
+                },
+            });
+            makeTestFromCase({
+                test: 'nullsfirst true added in meta overrides the default sort order',
+                method,
+                config: {
+                    sortOrder:
+                        PostgRestSortOrder.AscendingNullsLastDescendingNullsFirst,
+                },
+                resource: 'posts',
+                params: {
+                    pagination: {
+                        page: 1,
+                        perPage: 10,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                    filter: {},
+                    meta: { nullsfirst: true },
+                },
+                expectedUrl: `/posts?offset=0&limit=10&order=id.asc.nullsfirst`,
+                expectedOptions: {
+                    headers: {
+                        accept: 'application/json',
+                        prefer: 'count=exact',
+                    },
+                },
+                httpClientResponseHeaders: {
+                    'content-range': '0-9/100',
+                },
+            });
+            makeTestFromCase({
+                test: 'nullsfirst false added in meta overrides the default sort order',
+                method,
+                config: {
+                    sortOrder:
+                        PostgRestSortOrder.AscendingNullsFirstDescendingNullsFirst,
+                },
+                resource: 'posts',
+                params: {
+                    pagination: {
+                        page: 1,
+                        perPage: 10,
+                    },
+                    sort: {
+                        field: 'id',
+                        order: 'ASC',
+                    },
+                    filter: {},
+                    meta: { nullsfirst: false },
+                },
+                expectedUrl: `/posts?offset=0&limit=10&order=id.asc`,
+                expectedOptions: {
+                    headers: {
+                        accept: 'application/json',
+                        prefer: 'count=exact',
+                    },
+                },
+                httpClientResponseHeaders: {
+                    'content-range': '0-9/100',
+                },
+            });
+        });
+    });
+
+    describe('nullslast', () => {
+        makeTestFromCase({
+            test: 'nullslast true added in meta changes the sort order',
+            method,
+            resource: 'posts',
+            params: {
+                pagination: {
+                    page: 1,
+                    perPage: 10,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: { nullslast: true },
+            },
+            expectedUrl: `/posts?offset=0&limit=10&order=id.desc.nullslast`,
+            expectedOptions: {
+                headers: {
+                    accept: 'application/json',
+                    prefer: 'count=exact',
+                },
+            },
+            httpClientResponseHeaders: {
+                'content-range': '0-9/100',
+            },
+        });
+        makeTestFromCase({
+            test: 'nullslast true added in meta is compatible with the default sort order',
+            method,
+            config: {
+                sortOrder:
+                    PostgRestSortOrder.AscendingNullsLastDescendingNullsLast,
+            },
+            resource: 'posts',
+            params: {
+                pagination: {
+                    page: 1,
+                    perPage: 10,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: { nullslast: true },
+            },
+            expectedUrl: `/posts?offset=0&limit=10&order=id.desc.nullslast`,
+            expectedOptions: {
+                headers: {
+                    accept: 'application/json',
+                    prefer: 'count=exact',
+                },
+            },
+            httpClientResponseHeaders: {
+                'content-range': '0-9/100',
+            },
+        });
+        makeTestFromCase({
+            test: 'nullslast true added in meta overrides the default sort order',
+            method,
+            config: {
+                sortOrder:
+                    PostgRestSortOrder.AscendingNullsFirstDescendingNullsFirst,
+            },
+            resource: 'posts',
+            params: {
+                pagination: {
+                    page: 1,
+                    perPage: 10,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: { nullslast: true },
+            },
+            expectedUrl: `/posts?offset=0&limit=10&order=id.desc.nullslast`,
+            expectedOptions: {
+                headers: {
+                    accept: 'application/json',
+                    prefer: 'count=exact',
+                },
+            },
+            httpClientResponseHeaders: {
+                'content-range': '0-9/100',
+            },
+        });
+        makeTestFromCase({
+            test: 'nullslast false added in meta overrides the default sort order',
+            method,
+            config: {
+                sortOrder:
+                    PostgRestSortOrder.AscendingNullsLastDescendingNullsLast,
+            },
+            resource: 'posts',
+            params: {
+                pagination: {
+                    page: 1,
+                    perPage: 10,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
+                meta: { nullslast: false },
+            },
+            expectedUrl: `/posts?offset=0&limit=10&order=id.desc`,
+            expectedOptions: {
+                headers: {
+                    accept: 'application/json',
+                    prefer: 'count=exact',
+                },
+            },
+            httpClientResponseHeaders: {
+                'content-range': '0-9/100',
+            },
+        });
+    });
 });

--- a/tests/dataProvider/helper.ts
+++ b/tests/dataProvider/helper.ts
@@ -10,7 +10,8 @@ function createDataProviderMock(
     mockedResponseBody: string,
     mockedResponseJSON?: any,
     mockedResponseOptions?: Record<string, any>,
-    mockedCustomSchema?: () => string
+    mockedCustomSchema?: () => string,
+    config?: Partial<IDataProviderConfig>
 ) {
     const httpClient = jest.fn((url, options) =>
         Promise.resolve({
@@ -21,19 +22,20 @@ function createDataProviderMock(
         })
     );
 
-    const customSchema : () => string = mockedCustomSchema ? mockedCustomSchema : () => ("");
+    const customSchema: () => string = mockedCustomSchema
+        ? mockedCustomSchema
+        : () => '';
 
     const dataProviderConfig: IDataProviderConfig = {
         apiUrl: BASE_URL,
         httpClient: httpClient,
         defaultListOp: 'eq',
         primaryKeys: resourcePrimaryKeys,
-        schema: customSchema
-    }
+        schema: customSchema,
+        ...config,
+    };
 
-    const dataProvider = raPostgrestProvider(
-        dataProviderConfig
-    );
+    const dataProvider = raPostgrestProvider(dataProviderConfig);
 
     return { httpClient, dataProvider };
 }
@@ -48,8 +50,9 @@ export type Case = {
     expectedUrl?: string;
     expectedOptions?: Record<string, any>;
     expectedResult?: any;
-    schema?: () => (string);
+    schema?: () => string;
     throws?: RegExp;
+    config?: Partial<IDataProviderConfig>;
 };
 
 export const makeTestFromCase = ({
@@ -64,6 +67,7 @@ export const makeTestFromCase = ({
     expectedResult,
     schema,
     throws,
+    config,
 }: Case) => {
     it(`${method} > ${test}`, async () => {
         const { httpClient, dataProvider } = createDataProviderMock(
@@ -71,7 +75,8 @@ export const makeTestFromCase = ({
             '',
             httpClientResponseBody,
             httpClientResponseHeaders,
-            schema
+            schema,
+            config
         );
 
         let dataProviderResult;


### PR DESCRIPTION
- Export PostgRestSortOrder as const to allow overriding the sortOrder with TypeScript validation
- use the sortOrder config option in getList
- Allow to override the nullsfirst/nullslast in getList sort

Closes #163, #162, #160