### PR TITLE
Fix getMany fails when called with an empty array of ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,9 @@ export default (config: IDataProviderConfig): DataProvider => ({
 
     getMany: (resource, params: Partial<GetManyParams> = {}) => {
         const ids = params.ids;
+        if (ids.length === 0) {
+            return Promise.resolve({ data: [] });
+        }
         const primaryKey = getPrimaryKey(resource, config.primaryKeys);
 
         const query = getQuery(primaryKey, ids, resource, params.meta);

--- a/tests/dataProvider/getMany.test.ts
+++ b/tests/dataProvider/getMany.test.ts
@@ -1,0 +1,25 @@
+import { makeTestFromCase, Case } from './helper';
+import dataProviderBuilder from '../../src';
+
+describe('getMany specific', () => {
+    const method = 'getMany';
+
+    const cases: Case[] = [
+        {
+            test: 'Read a list of resource, by ids',
+            method,
+            resource: 'posts',
+            params: { ids: [1, 2, 3] },
+            expectedUrl: `/posts?id=in.%28${encodeURIComponent('1,2,3')}%29`,
+            expectedOptions: { headers: {} },
+        },
+    ];
+
+    cases.forEach(makeTestFromCase);
+
+    it('should not fail when no ids are provided', async () => {
+        const dataProvider = dataProviderBuilder({} as any);
+        const { data } = await dataProvider.getMany('posts', { ids: [] });
+        expect(data).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #158