### PR TITLE
Add support for embed and prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,86 @@ columns: ['id', 'json_data->>blood_type', 'json_data->phones']
 
 **Note**: not working for `create` and `updateMany`.
 
+### Embeds and prefetch
+
+`ra-data-postgrest` supports React Admin [embed](https://marmelab.com/react-admin/DataProviders.html#embedding-relationships) and [prefetch](https://marmelab.com/react-admin/DataProviders.html#prefetching-relationships) features.
+
+For instance, here's how to prefetch posts authors (many-to-one relationship):
+
+```jsx
+import { Datagrid, List, ReferenceField, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List queryOptions={{ meta: { prefetch: ['authors'] } }}>
+        <Datagrid>
+            <TextField source="title" />
+            <ReferenceField source="author_id" reference="authors" />
+        </Datagrid>
+    </List>
+)
+```
+
+Here's how to embed posts authors instead:
+
+```jsx
+import { Datagrid, List, ReferenceField, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List queryOptions={{ meta: { embed: ['authors'] } }}>
+        <Datagrid>
+            <TextField source="title" />
+            <TextField source="authors.name" />
+        </Datagrid>
+    </List>
+)
+```
+
+This will result in a single query to the database and populate React Admin cache for the `authors` resource.
+
+This works for one-to-many relationships too. For instance, here's how to prefetch all books from an author:
+
+```jsx
+import { Show, SimpleShowLayout, ReferenceManyField, Datagrid, TextField, DateField } from 'react-admin';
+
+const AuthorShow = () => (
+    <Show queryOptions={{ meta: { prefetch: ['books'] } }}>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <ReferenceManyField reference="books" target="author_id" label="Books">
+              <Datagrid>
+                <TextField source="title" />
+                <DateField source="published_at" />
+              </Datagrid>
+            </ReferenceManyField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+Here's how to embed the books instead:
+
+```jsx
+import { Show, SimpleShowLayout, ArrayField, Datagrid, TextField, DateField } from 'react-admin';
+
+const AuthorShow = () => (
+    <Show queryOptions={{ meta: { prefetch: ['books'] } }}>
+        <SimpleShowLayout>
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <ArrayField source="books">
+              <Datagrid>
+                <TextField source="title" />
+                <DateField source="published_at" />
+              </Datagrid>
+            </ArrayField>
+        </SimpleShowLayout>
+    </Show>
+);
+```
+
+This will result in a single query to the database and populate React Admin cache for the `books` resource.
+
 ## Developers notes
 
 The current development of this library was done with node v19.10 and npm 8.19.3. In this version the unit tests and the development environment should work.

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -168,6 +168,15 @@ export const parseFilters = (
             : meta.columns;
     }
 
+    if (meta?.embed || meta?.prefetch) {
+        const columns = getColumnsParam(meta.embed, meta.prefetch);
+        if (columns) {
+            result.select = result.select
+                ? `${result.select},${columns.join(',')}`
+                : `*,${columns.join(',')}`;
+        }
+    }
+
     return result;
 };
 
@@ -295,6 +304,16 @@ export const getQuery = (
             : meta.columns;
     }
 
+    if (meta?.embed || meta?.prefetch) {
+        const columns = getColumnsParam(meta.embed, meta.prefetch);
+        if (columns) {
+            result.select = result.select
+                ? `${result.select},${columns.join(',')}`
+                // if users did not specify any columns, we must add the wildcard select to not get only the embeds/prefetch 
+                : `*,${columns.join(',')}`;
+        }
+    }
+
     return result;
 };
 
@@ -317,4 +336,15 @@ export const getOrderBy = (
     } else {
         return `${field}.${postgRestOrder}`;
     }
+};
+
+/**
+ * Compute the columns parameter for the embed and prefetch query meta properties
+ */
+const getColumnsParam = (embed: string[], prefetch: string[]) => {
+    if (!embed && !prefetch) return;
+    const param = new Set<string>();
+    if (embed) embed.forEach(resource => param.add(`${resource}(*)`));
+    if (prefetch) prefetch.forEach(resource => param.add(`${resource}(*)`));
+    return Array.from(param);
 };

--- a/tests/dataProvider/create.test.ts
+++ b/tests/dataProvider/create.test.ts
@@ -1,4 +1,4 @@
-import { SINGLE_TODO } from '../fixtures';
+import { SINGLE_TODO, SINGLE_TODO_WITH_USER } from '../fixtures';
 import { makeTestFromCase, Case } from './helper';
 
 describe('create specific', () => {
@@ -31,6 +31,71 @@ describe('create specific', () => {
             httpClientResponseBody: SINGLE_TODO,
             expectedResult: {
                 data: SINGLE_TODO,
+                meta: undefined,
+            },
+        },
+        {
+            test: 'should not remove the embedded data from the result nor add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                data: {
+                    todo: SINGLE_TODO.todo,
+                    user_id: SINGLE_TODO.user_id,
+                },
+                meta: { embed: ['users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_USER,
+            expectedUrl: '/todos?select=%2A%2Cusers%28%2A%29',
+            expectedOptions: {
+                method: 'POST',
+                body: JSON.stringify({
+                    todo: SINGLE_TODO.todo,
+                    user_id: SINGLE_TODO.user_id,
+                }),
+                headers: {
+                    accept: 'application/vnd.pgrst.object+json',
+                    prefer: 'return=representation',
+                    'content-type': 'application/json',
+                },
+            },
+            expectedResult: {
+                data: SINGLE_TODO_WITH_USER,
+                meta: undefined,
+            },
+        },
+        {
+            test: 'should remove the prefetched data from the result and add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                data: {
+                    todo: SINGLE_TODO.todo,
+                    user_id: SINGLE_TODO.user_id,
+                },
+                meta: { prefetch: ['users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_USER,
+            expectedUrl: '/todos?select=%2A%2Cusers%28%2A%29',
+            expectedOptions: {
+                method: 'POST',
+                body: JSON.stringify({
+                    todo: SINGLE_TODO.todo,
+                    user_id: SINGLE_TODO.user_id,
+                }),
+                headers: {
+                    accept: 'application/vnd.pgrst.object+json',
+                    prefer: 'return=representation',
+                    'content-type': 'application/json',
+                },
+            },
+            expectedResult: {
+                data: SINGLE_TODO,
+                meta: {
+                    prefetched: {
+                        users: [{ id: 3, name: 'user_3' }],
+                    },
+                },
             },
         },
     ];

--- a/tests/dataProvider/getOne.test.ts
+++ b/tests/dataProvider/getOne.test.ts
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import { makeTestFromCase, Case } from './helper';
+import { SINGLE_TODO, SINGLE_TODO_WITH_TAGS_USER } from '../fixtures';
 
 describe('getOne specific', () => {
     const method = 'getOne';
@@ -27,7 +28,9 @@ describe('getOne specific', () => {
             params: {
                 id: JSON.stringify([1, 'X']),
             },
-            expectedUrl: '/contacts?'.concat(qs.stringify({and: '(id.eq.1,type.eq.X)'})),
+            expectedUrl: '/contacts?'.concat(
+                qs.stringify({ and: '(id.eq.1,type.eq.X)' })
+            ),
             expectedOptions,
         },
         {
@@ -52,6 +55,45 @@ describe('getOne specific', () => {
         //     expectedUrl: `/rpc/get_contact?and=(id.eq.1,type.eq.X)`,
         //     expectedOptions,
         // },
+        {
+            test: 'should not remove the embedded data from the result nor add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                id: 2,
+                meta: { embed: ['tags', 'users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_TAGS_USER,
+            expectedUrl:
+                '/todos?id=eq.2&select=%2A%2Ctags%28%2A%29%2Cusers%28%2A%29',
+            expectedOptions,
+            expectedResult: {
+                data: SINGLE_TODO_WITH_TAGS_USER,
+                meta: undefined,
+            },
+        },
+        {
+            test: 'should remove the prefetched data from the result and add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                id: 2,
+                meta: { prefetch: ['tags', 'users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_TAGS_USER,
+            expectedUrl:
+                '/todos?id=eq.2&select=%2A%2Ctags%28%2A%29%2Cusers%28%2A%29',
+            expectedOptions,
+            expectedResult: {
+                data: SINGLE_TODO,
+                meta: {
+                    prefetched: {
+                        tags: [{ id: 1, name: 'tag_1' }],
+                        users: [{ id: 3, name: 'user_3' }],
+                    },
+                },
+            },
+        },
     ];
 
     cases.forEach(makeTestFromCase);

--- a/tests/dataProvider/update.test.ts
+++ b/tests/dataProvider/update.test.ts
@@ -1,6 +1,7 @@
 import qs from 'qs';
 import { makeTestFromCase, Case } from './helper';
 import dataProviderBuilder from '../../src';
+import { SINGLE_TODO, SINGLE_TODO_WITH_TAGS_USER } from '../fixtures';
 
 describe('update specific', () => {
     const method = 'update';
@@ -26,6 +27,65 @@ describe('update specific', () => {
                     accept: 'application/vnd.pgrst.object+json',
                     prefer: 'return=representation',
                     'content-type': 'application/json',
+                },
+            },
+        },
+        {
+            test: 'should not remove the embedded data from the result nor add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                id: 2,
+                data: { todo: 'item_2' },
+                previousData: { name: 'item_2_old' },
+                meta: { embed: ['tags', 'users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_TAGS_USER,
+            expectedUrl:
+                '/todos?id=eq.2&select=%2A%2Ctags%28%2A%29%2Cusers%28%2A%29',
+            expectedOptions: {
+                method: 'PATCH',
+                body: JSON.stringify({ todo: 'item_2' }),
+                headers: {
+                    accept: 'application/vnd.pgrst.object+json',
+                    prefer: 'return=representation',
+                    'content-type': 'application/json',
+                },
+            },
+            expectedResult: {
+                data: SINGLE_TODO_WITH_TAGS_USER,
+                meta: undefined,
+            },
+        },
+        {
+            test: 'should remove the prefetched data from the result and add it to the meta',
+            method,
+            resource: 'todos',
+            params: {
+                id: 2,
+                data: { todo: 'item_2' },
+                previousData: { name: 'item_2_old' },
+                meta: { prefetch: ['tags', 'users'] },
+            },
+            httpClientResponseBody: SINGLE_TODO_WITH_TAGS_USER,
+            expectedUrl:
+                '/todos?id=eq.2&select=%2A%2Ctags%28%2A%29%2Cusers%28%2A%29',
+            expectedOptions: {
+                method: 'PATCH',
+                body: JSON.stringify({ todo: 'item_2' }),
+                headers: {
+                    accept: 'application/vnd.pgrst.object+json',
+                    prefer: 'return=representation',
+                    'content-type': 'application/json',
+                },
+            },
+            expectedResult: {
+                data: SINGLE_TODO,
+                meta: {
+                    prefetched: {
+                        tags: [{ id: 1, name: 'tag_1' }],
+                        users: [{ id: 3, name: 'user_3' }],
+                    },
                 },
             },
         },

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -60,6 +60,101 @@ export const TODO_LIST = [
     },
 ];
 
+export const TODO_LIST_WITH_PREFETCHED_TAGS_USER = [
+    {
+        id: 1,
+        todo: 'item_1',
+        private: false,
+        mine: true,
+        user_id: 1,
+        users: { id: 1, name: 'user_1' },
+        tags: [{ id: 1, name: 'tag_1' }],
+    },
+    {
+        id: 2,
+        todo: 'item_2',
+        private: true,
+        mine: false,
+        user_id: 3,
+        users: { id: 3, name: 'user_3' },
+        tags: [{ id: 1, name: 'tag_1' }],
+    },
+    {
+        id: 3,
+        todo: 'item_3',
+        private: false,
+        mine: false,
+        user_id: 2,
+        users: { id: 2, name: 'user_2' },
+        tags: [
+            { id: 1, name: 'tag_1' },
+            { id: 2, name: 'tag_2' },
+        ],
+    },
+    {
+        id: 4,
+        todo: 'item_4',
+        private: true,
+        mine: true,
+        user_id: 1,
+        users: { id: 1, name: 'user_1' },
+        tags: [{ id: 2, name: 'tag_2' }],
+    },
+    {
+        id: 5,
+        todo: 'item_5',
+        private: true,
+        mine: false,
+        user_id: 3,
+        users: { id: 3, name: 'user_3' },
+        tags: [
+            { id: 2, name: 'tag_2' },
+            { id: 3, name: 'tag_3' },
+        ],
+    },
+    {
+        id: 6,
+        todo: 'item_6',
+        private: false,
+        mine: false,
+        user_id: 2,
+        users: { id: 2, name: 'user_2' },
+        tags: [{ id: 4, name: 'tag_4' }],
+    },
+];
+
+export const PREFETCHED_TAGS = [
+    { id: 1, name: 'tag_1' },
+    { id: 2, name: 'tag_2' },
+    { id: 3, name: 'tag_3' },
+    { id: 4, name: 'tag_4' },
+];
+
+export const PREFETCHED_USERS = [
+    { id: 1, name: 'user_1' },
+    { id: 3, name: 'user_3' },
+    { id: 2, name: 'user_2' },
+];
+
+export const SINGLE_TODO_WITH_USER =  {
+    id: 2,
+    todo: 'item_2',
+    private: true,
+    mine: false,
+    user_id: 3,
+    users: { id: 3, name: 'user_3' },
+};
+
+export const SINGLE_TODO_WITH_TAGS_USER =  {
+    id: 2,
+    todo: 'item_2',
+    private: true,
+    mine: false,
+    user_id: 3,
+    users: { id: 3, name: 'user_3' },
+    tags: [{ id: 1, name: 'tag_1' }],
+};
+
 export const SINGLE_CONTACT = {
     id: 1,
     type: 'X',


### PR DESCRIPTION
## Problem

React-admin introduced embed and prefetch in [5.3.0](https://github.com/marmelab/react-admin/releases/tag/v5.3.0).
`ra-data-postgrest` support a similar feature through the `columns` meta.

## Solution

Leverage the existing `meta` to support embed and prefetch